### PR TITLE
CHG: Connection#initialize now accepts a lambda for making socket

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ increase this with the `pool_size` option:
 Lowdown::Client.production(true, File.read("path/to/certificate.pem"), pool_size: 3)
 ```
 
+### Connect to APNS via proxy
+
+`Lowdown::Connection#initialize` accepts a lambda to build TCPSocket. Build a duck type of TCPSocket which go through proxy.
+
+```ruby
+socket_maker = lambda do |uri|
+  Proxifier::Proxy('http://127.0.0.1:3128').open \
+    uri.host, uri.port, nil, nil, Celluloid::IO::TCPSocket
+end
+
+connection_pool = Lowdown::Connection.pool \
+  size: 2,
+  args: [uri, cert.ssl_context, true, socket_maker]
+
+client = Lowdown::Client.client_with_connection connection_pool, certificate: cert
+```
+
 ## Gotchas
 
 * If you’re forking your process, be sure to **not** load lowdown before forking (because this [does not work well with

--- a/lib/lowdown/client.rb
+++ b/lib/lowdown/client.rb
@@ -223,7 +223,7 @@ module Lowdown
         end
       end
     ensure
-      group.terminate
+      group.try :terminate
     end
 
     # Registers a condition object with the connection pool, for the duration of the given block. It either returns an

--- a/lib/lowdown/client.rb
+++ b/lib/lowdown/client.rb
@@ -223,7 +223,7 @@ module Lowdown
         end
       end
     ensure
-      group.try :terminate
+      group.terminate
     end
 
     # Registers a condition object with the connection pool, for the duration of the given block. It either returns an

--- a/lib/lowdown/connection.rb
+++ b/lib/lowdown/connection.rb
@@ -86,18 +86,18 @@ module Lowdown
     # @param [lambda] socket_maker
     #        a lambda takes uri and returns duck type of TCPSocket
     #        e.g.:
-    #        ```
-    #        socket_maker = lambda do |uri|
-    #          Proxifier::Proxy('http://127.0.0.1:3128').open \
-    #          uri.host, uri.port, nil, nil, Celluloid::IO::TCPSocket
-    #        end
     #
-    #        connection_pool = Lowdown::Connection.pool \
-    #          size: 2,
-    #          args: [uri, cert.ssl_context, true, socket_maker]
+    # @example Use `socket_maker` argument with modified ruby-proxifier
+    #   socket_maker = lambda do |uri|
+    #     Proxifier::Proxy('http://127.0.0.1:3128').open \
+    #     uri.host, uri.port, nil, nil, Celluloid::IO::TCPSocket
+    #   end
     #
-    #        client = Lowdown::Client.client_with_connection connection_pool, certificate: cert
-    #        ```
+    #   connection_pool = Lowdown::Connection.pool \
+    #     size: 2,
+    #     args: [uri, cert.ssl_context, true, socket_maker]
+    #
+    #   client = Lowdown::Client.client_with_connection connection_pool, certificate: cert
     #
     def initialize(uri, ssl_context, connect = true, socket_maker = nil)
       @uri, @ssl_context = URI(uri), ssl_context

--- a/lib/lowdown/connection.rb
+++ b/lib/lowdown/connection.rb
@@ -182,7 +182,11 @@ module Lowdown
       # 2. This tries to `NilClass#send` the hostname:
       #    https://github.com/celluloid/celluloid-io/blob/85cee9da22ef5e94ba0abfd46454a2d56572aff4/lib/celluloid/io/dns_resolver.rb#L44
       begin
-        socket = @socket_maker.try(:call, @uri) || TCPSocket.new(@uri.host, @uri.port)
+        socket = if @socket_maker.respond_to? :call
+                   @socket_maker.call @uri
+                 else
+                   TCPSocket.new(@uri.host, @uri.port)
+                 end
       rescue NoMethodError
         raise SocketError, "(Probably) getaddrinfo: nodename nor servname provided, or not known"
       end

--- a/lib/lowdown/connection.rb
+++ b/lib/lowdown/connection.rb
@@ -397,3 +397,4 @@ module Lowdown
     end
   end
 end
+

--- a/lib/lowdown/connection.rb
+++ b/lib/lowdown/connection.rb
@@ -85,6 +85,19 @@ module Lowdown
     #
     # @param [lambda] socket_maker
     #        a lambda takes uri and returns duck type of TCPSocket
+    #        e.g.:
+    #        ```
+    #        socket_maker = lambda do |uri|
+    #          Proxifier::Proxy('http://127.0.0.1:3128').open \
+    #          uri.host, uri.port, nil, nil, Celluloid::IO::TCPSocket
+    #        end
+    #
+    #        connection_pool = Lowdown::Connection.pool \
+    #          size: 2,
+    #          args: [uri, cert.ssl_context, true, socket_maker]
+    #
+    #        client = Lowdown::Client.client_with_connection connection_pool, certificate: cert
+    #        ```
     #
     def initialize(uri, ssl_context, connect = true, socket_maker = nil)
       @uri, @ssl_context = URI(uri), ssl_context


### PR DESCRIPTION
so we could inject some duck type of TCPSocket into Connection, e.g. Proxifier::Proxy wrapped socket.